### PR TITLE
CRONAPP-2769 - ODATA: Erro ao passar nulo um campo com chave composta na inserção e atualização

### DIFF
--- a/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/access/data/JPAEntity.java
+++ b/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/access/data/JPAEntity.java
@@ -375,7 +375,12 @@ public class JPAEntity {
           if (((EdmSimplePropertyImplProv) edmProperty).getComposite() != null) {
             Map<String, Object> oDataEntryPropertiesComposite = new LinkedHashMap<String, Object>();
             String value = (String) oDataEntryProperties.get(propertyName);
-            String[] values = value.split(ODataJPAConfig.COMPOSITE_SEPARATOR);
+            String[] values = null;
+            if (value == null) {
+              values = new String[((EdmSimplePropertyImplProv)edmProperty).getComposite().size()];
+            } else {
+              values = value.split(ODataJPAConfig.COMPOSITE_SEPARATOR);
+            }
             int i = 0;
             for (EdmProperty p: ((EdmSimplePropertyImplProv)edmProperty).getComposite()) {
               if (isCreate == false && ((EdmSimplePropertyImplProv)p).getProperty().isOriginalId()) {

--- a/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/model/JPAEdmProperty.java
+++ b/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/model/JPAEdmProperty.java
@@ -345,7 +345,6 @@ public class JPAEdmProperty extends JPAEdmBaseViewImpl implements
         } else {
           compositeProperty.addComposite(p);
           p.setOriginalId(true);
-          p.setForeignKey(false);
           p.setOriginalName(p.getName());
         }
       }


### PR DESCRIPTION
Problema: Erro ao passar nulo um campo com chave composta na inserção e atualização

Solução: Tratado valor nulo na chave composta