### PR TITLE
CRONAPP-3107 - [Câmara] Pesquisa de caixa de seleção dinâmica, causando erro

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
@@ -868,6 +868,7 @@ public class FilterParserImpl implements FilterParser {
     // startswith
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(boolean_, string, string));
+    combination.add(new ParameterSet(boolean_, int32, string));
     lAvailableMethods.put(MethodOperator.STARTSWITH.toUriLiteral(), new InfoMethod(MethodOperator.STARTSWITH, 2, 2,
         combination));
 

--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
@@ -856,12 +856,14 @@ public class FilterParserImpl implements FilterParser {
     // endswith
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(boolean_, string, string));
+    combination.add(new ParameterSet(boolean_, int32, string));
     lAvailableMethods.put(MethodOperator.ENDSWITH.toUriLiteral(), new InfoMethod(MethodOperator.ENDSWITH, 2, 2,
         combination));
 
     // indexof
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(int32, string, string));
+    combination.add(new ParameterSet(int32, int32, string));
     lAvailableMethods.put(MethodOperator.INDEXOF.toUriLiteral(), new InfoMethod(MethodOperator.INDEXOF, 2, 2,
         combination));
 
@@ -897,6 +899,7 @@ public class FilterParserImpl implements FilterParser {
     // substringof
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(boolean_, string, string));
+    combination.add(new ParameterSet(boolean_, string, int32));
     lAvailableMethods.put(MethodOperator.SUBSTRINGOF.toUriLiteral(), new InfoMethod(MethodOperator.SUBSTRINGOF, 1, -1,
         combination));
 


### PR DESCRIPTION
Problema: filtrar iniciando, finalizando e contendo com campos inteiros
Solução: liberando odata para aceitar tipos inteiros nas expressões startswith, endswith e substringof