### PR TITLE
CRONAPP-3165 - [Câmara] Erro ao adicionar registro com chave tipo inteiro curto ou inteiro longo

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/edm/AbstractSimpleType.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/edm/AbstractSimpleType.java
@@ -55,12 +55,7 @@ public abstract class AbstractSimpleType implements EdmSimpleType {
 
   @Override
   public boolean isCompatible(final EdmSimpleType simpleType) {
-    if ((simpleType instanceof EdmDateTime
-        && this instanceof  EdmDateTimeOffset
-        || simpleType instanceof EdmDateTimeOffset
-        && this instanceof  EdmDateTime)
-        || simpleType instanceof EdmInt16
-        || simpleType instanceof EdmInt32) {
+    if (simpleType instanceof EdmDateTime && this instanceof  EdmDateTimeOffset || simpleType instanceof EdmDateTimeOffset && this instanceof  EdmDateTime) {
       return true;
     }
     return equals(simpleType);

--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.java
@@ -860,16 +860,22 @@ public class FilterParserImpl implements FilterParser {
     // tolower
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(string, string));
+    combination.add(new ParameterSet(string, int32));
+    combination.add(new ParameterSet(string, int16));
     lAvailableMethods.put(MethodOperator.TOLOWER.toUriLiteral(), new InfoMethod(MethodOperator.TOLOWER, combination));
 
     // toupper
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(string, string));
+    combination.add(new ParameterSet(string, int32));
+    combination.add(new ParameterSet(string, int16));
     lAvailableMethods.put(MethodOperator.TOUPPER.toUriLiteral(), new InfoMethod(MethodOperator.TOUPPER, combination));
 
     // trim
     combination = new ParameterSetCombination.PSCflex();
     combination.add(new ParameterSet(string, string));
+    combination.add(new ParameterSet(string, int32));
+    combination.add(new ParameterSet(string, int16));
     lAvailableMethods.put(MethodOperator.TRIM.toUriLiteral(), new InfoMethod(MethodOperator.TRIM, combination));
 
     // substring


### PR DESCRIPTION
Revertido o que havia sido feito por Lincon e colocado para tolower e toupper funcionar com inteiros