### PR TITLE
CRONAPP-3160 - [Câmara] Pesquisa de caixa de seleção dinâmica com loading infinito quando consulta contém group by

### DIFF
--- a/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/access/data/JPAProcessorImpl.java
+++ b/odata2-jpa-processor/jpa-core/src/main/java/org/apache/olingo/odata2/jpa/processor/core/access/data/JPAProcessorImpl.java
@@ -228,8 +228,8 @@ public class JPAProcessorImpl implements JPAProcessor {
     Query query = queryBuilder.build(resultsView);
     setPositionalParametersToQuery(query);
     List<?> resultList = query.getResultList();
-    if (resultList != null && resultList.size() > 0) {
-      if (resultList.size() > 1) {
+    if (resultList != null && !resultList.isEmpty()) {
+      if (resultList.size() > 1 || query.toString().toLowerCase().contains("group by")) {
         return resultList.size();
       }
       try {


### PR DESCRIPTION
Solução
É verificado se a query contém GROUP BY e caso contenha o count retornado do OData é exatamente o tamanho da lista.